### PR TITLE
#176 updated donor fields for pre-alpha

### DIFF
--- a/app/controllers/donors_controller.rb
+++ b/app/controllers/donors_controller.rb
@@ -81,16 +81,21 @@ class DonorsController < ApplicationController
 	def donor_params
 		params.require(:donor).permit(
 			:id,
-			:account_status,
+			:email,
+			:password,
+			:first_name,
+			:last_name,
+			:organization_name,
 			:address_street,
 			:address_city,
 			:address_state,
 			:address_zip,
-			:business_license,
-			:email,
-			:organization_name,
-			:password,
-			:pickup_instructions
+			:account_status,
+			:pickup_instructions,
+			# :business_license,
+			# :business_phone_number,
+			# :business_doc_id,
+			# :profile_pic_link
 		)
 	end
 end

--- a/app/models/donor.rb
+++ b/app/models/donor.rb
@@ -4,16 +4,23 @@ class Donor < ApplicationRecord
 	has_many :donations
 	has_many :claims, through: :donations
 	accepts_nested_attributes_for :claims
-	
-	validates :organization_name, presence: true
+
 	validates :email, uniqueness: { case_sensitive: false }
-	validates :business_license, presence: true
+	validates :first_name, presence: true
+	validates :last_name, presence: true
+	validates :organization_name, presence: true
 	validates :address_street, presence: true
 	validates :address_city, presence: true
 	validates :address_state, presence: true
 	validates :address_zip, presence: true
-	#TODO: add operation hours ??
-
+	validates :account_status, presence: true
+	validates :pickup_instructions, presence: true
+	# validates :business_license, presence: true 	     # commented out for pre-alpha
+	# validates :business_phone_number, presence: true   # commented out for pre-alpha
+	# validates :business_doc_id, presence: true         # commented out for pre-alpha
+	# validates :profile_pic_link, presence: true        # commented out for pre-alpha
+	# TODO: add operation hours ??
+	
 	geocoded_by :address
 	after_validation :geocode
 	def address

--- a/app/models/donor.rb
+++ b/app/models/donor.rb
@@ -5,7 +5,7 @@ class Donor < ApplicationRecord
 	has_many :claims, through: :donations
 	accepts_nested_attributes_for :claims
 
-	validates :email, uniqueness: { case_sensitive: false }
+	validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }, uniqueness: { case_sensitive: false }
 	validates :first_name, presence: true
 	validates :last_name, presence: true
 	validates :organization_name, presence: true
@@ -15,10 +15,10 @@ class Donor < ApplicationRecord
 	validates :address_zip, presence: true
 	validates :account_status, presence: true
 	validates :pickup_instructions, presence: true
-	# validates :business_license, presence: true 	     # commented out for pre-alpha
-	# validates :business_phone_number, presence: true   # commented out for pre-alpha
-	# validates :business_doc_id, presence: true         # commented out for pre-alpha
-	# validates :profile_pic_link, presence: true        # commented out for pre-alpha
+	# validates :business_license, presence: true, length: { is: 9 }  # commented out for pre-alpha
+	# validates :business_phone_number, presence: true                # commented out for pre-alpha
+	# validates :business_doc_id, presence: true                      # commented out for pre-alpha
+	# validates :profile_pic_link, presence: true                     # commented out for pre-alpha
 	# TODO: add operation hours ??
 	
 	geocoded_by :address

--- a/app/serializers/donor_serializer.rb
+++ b/app/serializers/donor_serializer.rb
@@ -1,13 +1,18 @@
 class DonorSerializer < ActiveModel::Serializer
   attributes :id,
-    :account_status,
+    :email,
+    :first_name,
+    :last_name,
+    :organization_name,
     :address_street,
     :address_city,
     :address_state,
     :address_zip,
-    :business_license,
-    :donations,
-    :email,
-    :organization_name,
+    :account_status,
     :pickup_instructions
+    :donations,
+    # :business_license,        # commented out for pre-alpha
+    # :business_phone_number,   # commented out for pre-alpha
+    # :business_doc_id,         # commented out for pre-alpha
+    # :profile_pic_link,        # commented out for pre-alpha
 end

--- a/app/serializers/donor_serializer.rb
+++ b/app/serializers/donor_serializer.rb
@@ -9,7 +9,7 @@ class DonorSerializer < ActiveModel::Serializer
     :address_state,
     :address_zip,
     :account_status,
-    :pickup_instructions
+    :pickup_instructions,
     :donations,
     # :business_license,        # commented out for pre-alpha
     # :business_phone_number,   # commented out for pre-alpha

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,6 +9,8 @@ Donor.destroy_all
 puts "Seeding Donors..."
 
 donor1 = Donor.create!(
+	first_name: "Nancy",
+	last_name: "McFood",
 	organization_name: "Foods 4 U",
 	email: "donor@donor.com",
 	password: "donor",
@@ -18,9 +20,14 @@ donor1 = Donor.create!(
 	address_zip: 98104,
 	business_license: "9198DD435AS3456",
 	account_status: "active",
-	pickup_instructions: 'Please go to the front desk.'
+	pickup_instructions: 'Please go to the front desk.',
+	 business_phone_number: '8675309',
+	 business_doc_id: '8675309',
+	 profile_pic_link: 'http://www.link.com'
 )
 donor2 = Donor.create(
+	first_name: "Bob",
+	last_name: "Binkler",
 	organization_name: "Unapproved",
 	email: "approve@me.com",
 	password: "approve",
@@ -30,9 +37,14 @@ donor2 = Donor.create(
 	address_zip: 98134,
 	business_license: "DSJ0984DFGK32",
 	account_status: "pending",
-	pickup_instructions: 'Please go to the front desk.'
+	pickup_instructions: 'Please go to the front desk.',
+	 business_phone_number: '8675309',
+	 business_doc_id: '8675309',
+	 profile_pic_link: 'http://www.link.com'
 )
 donor3 = Donor.create(
+	first_name: "Rachel",
+	last_name: "Maneshevitz",
 	organization_name: "ABC Grocery",
 	email: "donor3@donor3.com",
 	password: "donor3",
@@ -42,9 +54,14 @@ donor3 = Donor.create(
 	address_zip: 98005,
 	business_license: "123456789",
 	account_status: "approved",
-	pickup_instructions: 'Please go to the front desk.'
+	pickup_instructions: 'Please go to the front desk.',
+	 business_phone_number: '8675309',
+	 business_doc_id: '8675309',
+	 profile_pic_link: 'http://www.link.com'
 )
 donor4 = Donor.create(
+	first_name: "Gigi",
+	last_name: "Goode",
 	organization_name: "Good Food Restaurant",
 	email: "donor4@donor4.com",
 	password: "donor4",
@@ -54,9 +71,14 @@ donor4 = Donor.create(
 	address_zip: 98101,
 	business_license: "123456789",
 	account_status: "approved",
-	pickup_instructions: 'Please go to the front desk.'
+	pickup_instructions: 'Please go to the front desk.',
+	 business_phone_number: '8675309',
+	 business_doc_id: '8675309',
+	 profile_pic_link: 'http://www.link.com'
 )
 donor5 = Donor.create(
+	first_name: "Serenity",
+	last_name: "Now",
 	organization_name: "A Coffeeshop",
 	email: "donor5@donor5.com",
 	password: "donor5",
@@ -66,9 +88,14 @@ donor5 = Donor.create(
 	address_zip: 98104,
 	business_license: "123456789",
 	account_status: "approved",
-	pickup_instructions: 'Please go to the front desk.'
+	pickup_instructions: 'Please go to the front desk.',
+	 business_phone_number: '8675309',
+	 business_doc_id: '8675309',
+	 profile_pic_link: 'http://www.link.com'
 	)
 donor6 = Donor.create(
+	first_name: "Chad",
+	last_name: "Charles",
 	organization_name: "Chad's Deli",
 	email: "donor6@donor6.com",
 	password: "donor6",
@@ -78,9 +105,14 @@ donor6 = Donor.create(
 	address_zip: 98104,
 	business_license: "123456789",
 	account_status: "approved",
-	pickup_instructions: 'Please go to the front desk.'
+	pickup_instructions: 'Please go to the front desk.',
+	 business_phone_number: '8675309',
+	 business_doc_id: '8675309',
+	 profile_pic_link: 'http://www.link.com'
 )
 donor7 = Donor.create(
+	first_name: "Joanna",
+	last_name: "Soto",
 	organization_name: "Fancy Foods",
 	email: "donor7@donor7.com",
 	password: "donor7",
@@ -90,9 +122,14 @@ donor7 = Donor.create(
 	address_zip: 98122,
 	business_license: "123456789",
 	account_status: "approved",
-	pickup_instructions: 'Please go to the front desk.'
+	pickup_instructions: 'Please go to the front desk.',
+	 business_phone_number: '8675309',
+	 business_doc_id: '8675309',
+	 profile_pic_link: 'http://www.link.com'
 )
 donor8 = Donor.create(
+	first_name: "Issa",
+	last_name: "Rae",
 	organization_name: "XYZ Grocery",
 	email: "donor8@donor8.com",
 	password: "donor8",
@@ -102,9 +139,14 @@ donor8 = Donor.create(
 	address_zip: 98102,
 	business_license: "123456789",
 	account_status: "approved",
-	pickup_instructions: 'Please go to the front desk.'
+	pickup_instructions: 'Please go to the front desk.',
+	 business_phone_number: '8675309',
+	 business_doc_id: '8675309',
+	 profile_pic_link: 'http://www.link.com'
 )
 donor9 = Donor.create(
+	first_name: "Greta",
+	last_name: "Thunberg",
 	organization_name: "Dangerousway",
 	email: "donor9@donor9.com",
 	password: "donor9",
@@ -114,9 +156,14 @@ donor9 = Donor.create(
 	address_zip: 98101,
 	business_license: "123456789",
 	account_status: "approved",
-	pickup_instructions: 'Please go to the front desk.'
+	pickup_instructions: 'Please go to the front desk.',
+	 business_phone_number: '8675309',
+	 business_doc_id: '8675309',
+	 profile_pic_link: 'http://www.link.com'
 )
 donor10 = Donor.create(
+	first_name: "Sasha",
+	last_name: "Fierce",
 	organization_name: "Macco Groceries",
 	email: "donor10@donor10.com",
 	password: "donor10",
@@ -126,7 +173,10 @@ donor10 = Donor.create(
 	address_zip: 98102,
 	business_license: "123456789",
 	account_status: "approved",
-	pickup_instructions: 'Please go to the front desk.'
+	pickup_instructions: 'Please go to the front desk.',
+	business_phone_number: '8675309',
+	business_doc_id: '8675309',
+	profile_pic_link: 'http://www.link.com'
 )
 
 puts "Seeding Donations..."


### PR DESCRIPTION
## Updated Donor Fields

#### Please check if the PR fulfills these requirements

- [x] The changes don't come from your master branch. ([Source](https://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)) 

---

### [Trello Card](https://trello.com/c/J6r7TR7h/176-update-create-update-donor-be-functions-with-new-inputs)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
*Commented out fields that won't be present in prealpha release*

#### What is the current behavior? (You can also link to an open issue here)
*Donor model, serializer and controller use/accept the following fields/params:*
  ```
  email
  password (abstracted away with `has_secure_password`)
  first_name
  last_name
  organization_name
  address_street
  address_city
  address_state
  address_zip
  account_status
  pickup_instructions
  business_license
  business_phone_number
  business_doc_id
  profile_pic_link
```
#### What is the new behavior? (if this is a feature change)
*Donor model, serializer and controller were updated to now **only** use/acccept the following fields/params:*
```
  email
  password (abstracted away with `has_secure_password`)
  first_name
  last_name
  organization_name
  address_street
  address_city
  address_state
  address_zip
  account_status
  pickup_instructions
```

#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
*No breaking changes that I'm aware of.*

#### Images (before/ after screenshots, interaction GIFs, ...)
*Tested in console:*
![image](https://user-images.githubusercontent.com/13320440/83340246-9cea2a80-a28a-11ea-9f34-3ad791dc6b53.png)

---


#### TODO
`email` and `business_license` verifications added on PR #55 should overwrite the verifications here.

