### PR TITLE
Notify client when donor/client email address is already in use.

### DIFF
--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -12,15 +12,9 @@ class ClientsController < ApplicationController
   end
 
   def create
-    begin
-      @client = Client.create!(client_params)
-    rescue ActiveRecord::RecordInvalid => err
-      if err.message.include? "Email has already been taken"
-        return render json: { error: 'client email already in use'}, status: :conflict
-      else
-        raise # re-raise exception and stop further request processing
-      end
-    end
+    return render json: { error: 'client email already in use'}, status: :conflict if Client.exists?({email: client_params[:email]})
+    @client = Client.create!(client_params)
+
     if @client.valid?
       @token = encode_token(client_id: @client.id)
       render json: { client: ClientSerializer.new(@client), jwt: @token }, status: :created

--- a/app/controllers/donors_controller.rb
+++ b/app/controllers/donors_controller.rb
@@ -14,7 +14,15 @@ class DonorsController < ApplicationController
 	end
 
 	def create
-		@donor = Donor.create!(donor_params)
+		begin
+			@donor = Donor.create!(donor_params)
+		rescue ActiveRecord::RecordInvalid => error
+			if error.message.include? "Email has already been taken"
+				return render json: { error: 'donor email already in use'}, status: :conflict
+			else
+				raise  # re-raise exception and stop further request processing
+			end
+		end
 		if @donor.valid?
 			@token = encode_token(donor_id: @donor.id)
 			session[:donor_id] = @donor.id

--- a/app/controllers/donors_controller.rb
+++ b/app/controllers/donors_controller.rb
@@ -14,15 +14,8 @@ class DonorsController < ApplicationController
 	end
 
 	def create
-		begin
-			@donor = Donor.create!(donor_params)
-		rescue ActiveRecord::RecordInvalid => error
-			if error.message.include? "Email has already been taken"
-				return render json: { error: 'donor email already in use'}, status: :conflict
-			else
-				raise  # re-raise exception and stop further request processing
-			end
-		end
+		return render json: { error: 'donor email already in use'}, status: :conflict if Donor.exists?({email: donor_params[:email]})
+		@donor = Donor.create!(donor_params)
 		if @donor.valid?
 			@token = encode_token(donor_id: @donor.id)
 			session[:donor_id] = @donor.id

--- a/test/controllers/clients_controller_test.rb
+++ b/test/controllers/clients_controller_test.rb
@@ -1,7 +1,20 @@
 require 'test_helper'
 
+
 class ClientsControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+
+  test "we return 409 status code in the event the client email is already present in the db" do
+    post clients_create_url, params: {client: { email: "client@client.com", password: "does not matter",
+                                                   address_zip: 90210, account_status: "pending"}}
+    assert_response :conflict
+  end
+
+  test "we successfully register a new client" do
+    post clients_create_url, params: {client: { email: "notindb@notindb.com", password: "password",
+                                                address_zip: 90210, account_status: "pending"}}
+    assert_response :success
+    just_added = Client.find_by_email("notindb@notindb.com")
+    assert_not_nil just_added
+  end
+
 end

--- a/test/controllers/donors_controller_test.rb
+++ b/test/controllers/donors_controller_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+
+class DonorsControllerTest < ActionDispatch::IntegrationTest
+
+  test "we return 409 status code in the event the donor email is already present in the db" do
+    post donors_create_url, params: {donor: { email: "donor@donor.com", password: "does not matter",
+                                                   address_zip: 90210, account_status: "pending"}}
+    assert_response :conflict
+  end
+
+  test "we successfully register a new donor" do
+    post donors_create_url, params: {donor: { email: "notindb@notindb.com", password: "password",
+                                              address_zip: 98104, account_status: "pending",
+                                              organization_name: "Uwajimaya", address_street: "600 5th Ave S",
+                                              address_city: "Seattle", address_state: "WA", business_license: "ADASDFG"}}
+    assert_response :success
+    just_added = Donor.find_by_email("notindb@notindb.com")
+    assert_not_nil just_added
+  end
+
+end

--- a/test/fixtures/documents.yml
+++ b/test/fixtures/documents.yml
@@ -1,9 +1,0 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-one:
-  title: MyString
-  contents: MyText
-
-two:
-  title: MyString
-  contents: MyText

--- a/test/fixtures/donors.yml
+++ b/test/fixtures/donors.yml
@@ -1,13 +1,12 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 first:
   id: 1
-  email: client@client.com
+  email: donor@donor.com
   password_digest: $2a$12$hHrN9ZObSjBUT7f4Wg4Kh.EuRYd5sEyyih9zhur1VbFPTVv3zv4vO
-  first_name: Client
-  last_name: McClient
   address_street: 1411 4th Ave
   address_city: Seattle
   address_state: Washington
   address_zip: 98101
   account_status: active
-  ethnicity: White
+  business_license: 9198DD435AS3456
+  organization_name: Ralphs Grocery Store


### PR DESCRIPTION
- [x] The changes don't come from your master branch. ([Source](https://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)) 

---

### [Trello Card](https://trello.com/c/1CelcVWJ/194-check-user-exists)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
New functionality


#### What is the current behavior? (You can also link to an open issue here)
Attempting to create a donor or a client using an email address that's already in either of those respective tables will result in an unhandled 500 error.  


#### What is the new behavior? (if this is a feature change)
Identify when ActiveRecord uniqueness validation has failed and return a specific HTTP status code (409) instead.  I'm open to suggestions for different status codes, but this seemed to be the closest fit.


#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
None.



#### Other information
I'll be opening a PR for the client shortly.



