### PR TITLE
Fix line feed issue with windows

### DIFF
--- a/.github/.gitattributes
+++ b/.github/.gitattributes
@@ -1,0 +1,1 @@
+text eol=lf


### PR DESCRIPTION
## Fixes
`entrypoint.sh` has had carriage returns in the file, resulting in the following error:
![image](https://user-images.githubusercontent.com/22226627/85906296-b9627f80-b7c2-11ea-9b30-2a6b6223e4c7.png)
Since this application is always running in a containerized setting, adding an enforcement of `LF` will make sure that `entrypoint.sh ` is executed inside of Docker.