### PR TITLE
Deploy on push to prealpha--http://ec2-54-167-200-156.compute-1.amazonaws.com:3000

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -19,7 +19,7 @@ jobs:
             sudo docker-compose down
             cd ..
             sudo rm -rf banana-rails
-            git clone git@github.com:sagehen03/banana-rails.git --depth=1
+            git clone git@github.com:FoodIsLifeBGP/banana-rails.git --depth=1
             cd banana-rails || exit 1
             touch dev.env
             sudo docker-compose up -d

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -2,7 +2,7 @@ name: Staging deploy
 on:
   push:
     branches:
-      - deploy-on-push # change to prealpha/main after testing
+      - prealpha/main
 jobs:
   deploy:
     name: deploy to staging
@@ -14,12 +14,11 @@ jobs:
           host: ${{ secrets.STG_SERVER }}
           key: ${{ secrets.STG_PRIVATE_KEY }}
           username: ubuntu
-          # remove branch reference before merging into prealpha
           script: |
             cd banana-rails || exit 1
             sudo docker-compose down
             cd ..
             sudo rm -rf banana-rails
-            git clone -b deploy-on-push git@github.com:FoodIsLifeBGP/banana-rails.git --depth=1
+            git clone git@github.com:FoodIsLifeBGP/banana-rails.git --depth=1
             cd banana-rails || exit 1
             sudo docker-compose up -d

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -14,12 +14,13 @@ jobs:
           host: ${{ secrets.STG_SERVER }}
           key: ${{ secrets.STG_PRIVATE_KEY }}
           username: ubuntu
+          # remove branch reference before merging into prealpha
           script: |
             cd banana-rails || exit 1
             sudo docker-compose down
             cd ..
             sudo rm -rf banana-rails
-            git clone git@github.com:FoodIsLifeBGP/banana-rails.git --depth=1
+            git clone git clone -b deploy-on-push git@github.com:FoodIsLifeBGP/banana-rails.git --depth=1
             cd banana-rails || exit 1
             touch dev.env
             sudo docker-compose up -d

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -20,7 +20,6 @@ jobs:
             sudo docker-compose down
             cd ..
             sudo rm -rf banana-rails
-            git clone git clone -b deploy-on-push git@github.com:FoodIsLifeBGP/banana-rails.git --depth=1
+            git clone -b deploy-on-push git@github.com:FoodIsLifeBGP/banana-rails.git --depth=1
             cd banana-rails || exit 1
-            touch dev.env
             sudo docker-compose up -d

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,0 +1,25 @@
+name: Staging deploy
+on:
+  push:
+    branches:
+      - deploy-on-push # change to prealpha/main after testing
+jobs:
+  deploy:
+    name: deploy to staging
+    runs-on: ubuntu-latest
+    steps:
+      - name: ssh to staging server, stop services, get fresh checkout, restart services
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.STG_SERVER }}
+          key: ${{ secrets.STG_PRIVATE_KEY }}
+          username: ubuntu
+          script: |
+            cd banana-rails || exit 1
+            sudo docker-compose down
+            cd ..
+            sudo rm -rf banana-rails
+            git clone git@github.com:sagehen03/banana-rails.git --depth=1
+            cd banana-rails || exit 1
+            touch dev.env
+            sudo docker-compose up -d

--- a/.github/workflows/staging-server.md
+++ b/.github/workflows/staging-server.md
@@ -26,12 +26,13 @@ and copy the public key to your clipboard and add it as deploy key for the repo:
 6. Add or update the `STG_SERVER` secret to the public DNS https://github.com/FoodIsLifeBGP/banana-rails/settings/secrets 
 (you'll need to be a repo owner)
 7. Add or update the `STG_PRIVATE_KEY` secret so that it's the private key string from step 2.
-8. Edit or add a security group that allows inbound traffic on port 3000.
+8. Edit or add an EC2 security group attached to your new instance that allows inbound traffic on port 3000.
 
 ##Todos
 1. Store instance private key and deploy key in 1password. 
 2. Use an easier to remember DNS (dev.bananapp.org or something).
 3. Review performance.
+4. Switch to an instance that belongs to the banana app AWS account.
 
 
     

--- a/.github/workflows/staging-server.md
+++ b/.github/workflows/staging-server.md
@@ -26,6 +26,7 @@ and copy the public key to your clipboard and add it as deploy key for the repo:
 6. Add or update the `STG_SERVER` secret to the public DNS https://github.com/FoodIsLifeBGP/banana-rails/settings/secrets 
 (you'll need to be a repo owner)
 7. Add or update the `STG_PRIVATE_KEY` secret so that it's the private key string from step 2.
+8. Edit or add a security group that allows inbound traffic on port 3000.
 
 
     

--- a/.github/workflows/staging-server.md
+++ b/.github/workflows/staging-server.md
@@ -10,7 +10,7 @@ coast availability zone or something like digital ocean.
 ## To set up and use new CD server
 1. Create new EC2 instance using an ubuntu image (ami-0ac80df6eff0e70b5 is what was used initially)
 2. Save the ssh keypair and make note of the public DNS
-3. ssh to the new instance `"ssh ~/.ssh/banana.pem" ubuntu@<public-dbs>`
+3. ssh to the new instance `"ssh ~/.ssh/banana.pem" ubuntu@<public-dns>`
 4. On the new EC2 instance install the following software. We can automate this as part of instance creation or save a new AWS image later.
     1. `sudo apt-get update`
     2. `curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -`
@@ -27,6 +27,9 @@ and copy the public key to your clipboard and add it as deploy key for the repo:
 (you'll need to be a repo owner)
 7. Add or update the `STG_PRIVATE_KEY` secret so that it's the private key string from step 2.
 8. Edit or add a security group that allows inbound traffic on port 3000.
+
+##Todos
+1. Store instance private key and deploy key in 1password. 
 
 
     

--- a/.github/workflows/staging-server.md
+++ b/.github/workflows/staging-server.md
@@ -1,0 +1,31 @@
+# AWS Staging Server Instructions
+
+## Notes 
+1. We're using docker for the postgres database and the database is reset with each deploy.
+2. The current instance is the cheapest one you can buy (t2.micro) in the 
+east coast availability zone.  We'll have to see how this works out in 
+terms of performance. We can consider using a bigger instance; switching to the west
+coast availability zone or something like digital ocean.
+
+## To set up and use new CD server
+1. Create new EC2 instance using an ubuntu image (ami-0ac80df6eff0e70b5 is what was used initially)
+2. Save the ssh keypair and make note of the public DNS
+3. ssh to the new instance `"ssh ~/.ssh/banana.pem" ubuntu@<public-dbs>`
+4. On the new EC2 instance install the following software. We can automate this as part of instance creation or save a new AWS image later.
+    1. `sudo apt-get update`
+    2. `curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -`
+    3. `sudo add-apt-repository    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+               $(lsb_release -cs) \
+               stable"`
+    4. `sudo apt-get update`
+    5. `sudo apt-get install docker-ce docker-ce-cli containerd.io`
+    6. `sudo curl -L "https://github.com/docker/compose/releases/download/1.26.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose`
+    7. `sudo chmod +x /usr/local/bin/docker-compose`
+5. Create a ssh keypair on the EC2 instance as described [here](https://docs.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key) 
+and copy the public key to your clipboard and add it as deploy key for the repo: https://github.com/FoodIsLifeBGP/banana-rails/settings/keys
+6. Add or update the `STG_SERVER` secret to the public DNS https://github.com/FoodIsLifeBGP/banana-rails/settings/secrets 
+(you'll need to be a repo owner)
+7. Add or update the `STG_PRIVATE_KEY` secret so that it's the private key string from step 2.
+
+
+    

--- a/.github/workflows/staging-server.md
+++ b/.github/workflows/staging-server.md
@@ -30,6 +30,8 @@ and copy the public key to your clipboard and add it as deploy key for the repo:
 
 ##Todos
 1. Store instance private key and deploy key in 1password. 
+2. Use an easier to remember DNS (dev.bananapp.org or something).
+3. Review performance.
 
 
     

--- a/README.md
+++ b/README.md
@@ -26,14 +26,6 @@ Banana App is an open-source, not-for-profit project of The Be Good Foundation. 
 
   to build and run the docker environment.
 
-- Run the command 
-
-  ```
-  docker-compose run web rails db:setup
-  ```
-
-  To initialize the container, hopefully you would only need to run it once. But if you rebuild the docker containers you might need to run it again.
-
 - Visit ``http://localhost:3000`` on your browser if you see the information
 
   ```json
@@ -91,14 +83,6 @@ Banana App is an open-source, not-for-profit project of The Be Good Foundation. 
   ```
 
   to build and run the docker environment.
-
-- Run the command in a new terminal window
-
-  ```
-  docker-compose run web rails db:setup
-  ```
-
-  To initialize the docker
 
 - Visit ``http://localhost:3000`` on your browser if you see the information
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,6 +42,6 @@ class ApplicationController < ActionController::API
     end
 
     def authorized
-      render json: { message: 'Please log in, testing' }, status: :unauthorized unless logged_in?
+      render json: { message: 'Please log in' }, status: :unauthorized unless logged_in?
     end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,6 +42,6 @@ class ApplicationController < ActionController::API
     end
 
     def authorized
-      render json: { message: 'Please log in' }, status: :unauthorized unless logged_in?
+      render json: { message: 'Please log in, testing' }, status: :unauthorized unless logged_in?
     end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -63,4 +63,5 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.hosts << "ec2-54-167-200-156.compute-1.amazonaws.com"
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,13 @@ services:
       - db
     env_file:
     - dev.env
+  ## run rails db:setup against the database so that the fixture data is in place
+  seeder:
+    command: rails db:setup
+    build: .
+    restart: on-failure
+    depends_on:
+      - db
 volumes:
   pgdata:
   


### PR DESCRIPTION
# Pull Request Template

#### Please check if the PR fulfills these requirements

- [x] The changes don't come from your master branch. ([Source](https://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)) 

---

### [Trello Card](trello.com/LINK-TO-TRELLO-CARD)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
New feature, upon pushing to prealpha, banana-rails should get deployed via docker to the EC2 instance accessible via: ec2-54-167-200-156.compute-1.amazonaws.com


#### What is the current behavior? (You can also link to an open issue here)
We don't have a shared backend server.  This will hopefully make it easier for FE devs. They should be able to point their environments.ts file to this host and not have to checkout or set up the rails app


#### What is the new behavior? (if this is a feature change)
See above.


#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
I don't think a failed deploy will impact pushing to the prealpha branch.



#### Other information



#### Discussion Questions



#### Images (before/ after screenshots, interaction GIFs, ...)


---


#### TODO
 - this
 - that
 - the other

