### PR TITLE
make sure docker set up works for both local and staging servers

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -2,7 +2,7 @@ name: Staging deploy
 on:
   push:
     branches:
-      - back-to-docker-db-gen
+      - prealpha/main
 jobs:
   deploy:
     name: deploy to staging

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -2,7 +2,7 @@ name: Staging deploy
 on:
   push:
     branches:
-      - prealpha/main
+      - back-to-docker-db-gen
 jobs:
   deploy:
     name: deploy to staging
@@ -22,6 +22,3 @@ jobs:
             git clone git@github.com:FoodIsLifeBGP/banana-rails.git --depth=1
             cd banana-rails || exit 1
             sudo docker-compose up -d
-            sleep 10
-            sudo docker-compose run web rails db:drop
-            sudo docker-compose run web rails db:setup

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -19,6 +19,7 @@ class DonationsController < ApplicationController
 	end
 
 	def create
+		puts 'hello!!'
 		@donation = Donation.create(donation_params)
 		if @donation.valid?
 			render json: { donation: DonationSerializer.new(@donation) }, status: :created

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -19,7 +19,6 @@ class DonationsController < ApplicationController
 	end
 
 	def create
-		puts 'hello!!'
 		@donation = Donation.create(donation_params)
 		if @donation.valid?
 			render json: { donation: DonationSerializer.new(@donation) }, status: :created

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - POSTGRES_HOST_AUTH_METHOD=trust
     ## expose the port 5432 in the db container to port 5432 in host machine, be sure that there is not runing instance in your machine.
     ports: 
-      - "5432:5432"
+      - "5433:5432"
   web:
     build: .
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
@@ -23,6 +23,13 @@ services:
       - db
     env_file:
     - dev.env
+  ## drops and recreates db so that the fixture data and latest migrations are in place
+  seeder:
+    command: bash -c "rails db:drop && rails db:setup"
+    build: .
+    restart: on-failure
+    depends_on:
+      - db
 volumes:
   pgdata:
   

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - POSTGRES_HOST_AUTH_METHOD=trust
     ## expose the port 5432 in the db container to port 5432 in host machine, be sure that there is not runing instance in your machine.
     ports: 
-      - "5433:5432"
+      - "5432:5432"
   web:
     build: .
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"


### PR DESCRIPTION
# Pull Request Template

#### Please check if the PR fulfills these requirements

- [x] The changes don't come from your master branch. ([Source](https://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)) 
We ran into an issue yesterday where a migration wasn't being applied to the staging server because rails db:setup is only supposed to be run against an empty database.  I was under the wrong impression that it could be run against an existing database.  I was also mistaken to think that our docker set up results in a fresh db each time, but we actually use a volume which persists the data between docker restarts.  I'm adding the change to drop the db first and then run db:setup.  This might impact folks who have data that it's in their database but not in seeder.rb.  I'm skeptical that there's anyone out there to whom that  scenario applies, but if I'm wrong we can figure something out.