### PR TITLE
Active donations api

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,4 +44,17 @@ class ApplicationController < ActionController::API
     def authorized
       render json: { message: 'Please log in' }, status: :unauthorized unless logged_in?
     end
+
+  def expire_donations_get_active(donations)
+    @active = Array.new
+    donations.each do |donation|
+      if donation.created_at < 1.day.ago
+        donation.status = DonationStatus::EXPIRED
+        donation.save
+      else
+        @active.push donation
+      end
+    end
+    @active
+  end
 end

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -8,10 +8,8 @@ class DonationsController < ApplicationController
 	end
 
 	def active
-		@active = Donation.all.select do |d|
-			d.status == DonationStatus::ACTIVE
-		end
-		render json: @active
+		@active_donations_in_db = Donation.where status: DonationStatus::ACTIVE
+		render json: expire_donations_get_active(@active_donations_in_db)
 	end
 
 	def show

--- a/app/controllers/donors_controller.rb
+++ b/app/controllers/donors_controller.rb
@@ -11,7 +11,7 @@ class DonorsController < ApplicationController
 		end
 		@donor = Donor.find(id)
 
-		render json: @donor.donations, include: 'claims', status: :ok
+		render json: expire_donations_get_active(@donor.donations), include: 'claims', status: :ok
 	end
 
 	def create

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   post 'donations/create', to: 'donations#create'
   post 'donations/:id/update', to: 'donations#update'
   post 'donations/:id/claim', to: 'donations#make_claim'
+  get 'donations/active', to: 'donations#active'
 
   get 'clients/:id/get_claims', to: 'clients#get_claims'
   post 'client_auth', to: 'client_auth#create'

--- a/test/controllers/donations_controller_test.rb
+++ b/test/controllers/donations_controller_test.rb
@@ -24,4 +24,16 @@ class DonationsControllerTest < ActionDispatch::IntegrationTest
     post donations_create_url, params: {donation: {}}
     assert_response :unauthorized
   end
+
+  test "active donations returns 1 record and marks another expired" do
+    active_donations = Donation.where status: DonationStatus::ACTIVE
+    assert_equal 2, active_donations.size, 'Should have found two donations with status=active, check donations.yml'
+    get '/donations/active', headers: auth_header({donor_id: 1})
+    assert_response :success
+    active_donations_api = JSON.parse @response.body
+    assert_equal 1, active_donations_api.size, 'should have returned one active donation'
+    assert_equal 'not expired food', active_donations_api[0]['food_name'], 'returned unexpected active donation, check donations.yml'
+    active_donations = Donation.where status: DonationStatus::ACTIVE
+    assert_equal 1, active_donations.size, 'Accessing the active donations through the api should have marked one expired'
+  end
 end

--- a/test/controllers/donors_controller_test.rb
+++ b/test/controllers/donors_controller_test.rb
@@ -55,4 +55,13 @@ class DonorsControllerTest < ActionDispatch::IntegrationTest
     assert_response :bad_request
   end
 
+  test "get donations for donor" do
+    active_donations_in_db = Donation.where status: DonationStatus::ACTIVE
+    assert_equal 2, active_donations_in_db.size, 'should initially have 2 donations with status = active'
+    get '/donors/1/get_donations', headers: auth_header({donor_id: 1})
+    assert_response :success
+    active_donations_api = JSON.parse @response.body
+    assert_equal 1, active_donations_api.size, 'should return only 1 active donation'
+  end
+
 end

--- a/test/fixtures/donations.yml
+++ b/test/fixtures/donations.yml
@@ -1,1 +1,28 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+to_expire:
+  id: 1
+  donor_id: 1
+  food_name: 'expired food'
+  created_at: <%= 2.days.ago %>
+  category: <%= DonationCategory::DAIRY %>
+  total_amount: '3 gallons'
+  pickup_instructions: 'Around the back'
+  status: <%= DonationStatus::ACTIVE %>
+active:
+  id: 2
+  donor_id: 1
+  food_name: 'not expired food'
+  created_at: <%= 2.hours.ago %>
+  category: <%= DonationCategory::DAIRY %>
+  total_amount: '3 gallons'
+  pickup_instructions: 'Around the back'
+  status: <%= DonationStatus::ACTIVE %>
+closed:
+  id: 3
+  donor_id: 1
+  food_name: 'closed donation'
+  created_at: <%= 3.days.ago %>
+  category: <%= DonationCategory::PRODUCE %>
+  total_amount: '1 bunch'
+  pickup_instructions: 'side door'
+  status: <%= DonationStatus::CLOSED %>


### PR DESCRIPTION
# Pull Request Template

#### Please check if the PR fulfills these requirements

- [x] The changes don't come from your master branch. ([Source](https://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)) 

---

### [Trello Card](trello.com/LINK-TO-TRELLO-CARD)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
New feature mostly.


#### What is the current behavior? (You can also link to an open issue here)
Active donations was not an exposed end point.


#### What is the new behavior? (if this is a feature change)
Expose active donations as an end point and now we want to update donations as expired if they still active and older than 24 hours when they are accessed via the api.


#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.


#### Other information
    1. expose an api to retrieve active donations
    2. a donation should automatically change from active to expired after 24 hours has elapsed.  There a multiple ways to do this, and I've elected to update the status when donations are retrieved via the api and their created_at value is more than 24 hours old.
    3. add unit tests to verify the behavior in step 2.
    
    We need to be mindful of how rails and postgres time zone settings interact.



#### Discussion Questions



#### Images (before/ after screenshots, interaction GIFs, ...)


---


#### TODO
 - this
 - that
 - the other

