### PR TITLE
Restrict donations to a radius search and include distance to client's location when client coords are passed

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -45,18 +45,18 @@ class ApplicationController < ActionController::API
     end
 
   def expire_donations(donations)
-    @active = Array.new
+    active = Array.new
     donations.each do |donation|
-      if donation.created_at < 1.day.ago && donation.status == DonationStatus::ACTIVE
+      if donation.created_at < 1.day.ago && (donation.status == DonationStatus::ACTIVE || donation.status == DonationStatus::CLAIMED)
         donation.status = DonationStatus::EXPIRED
         donation.claims.select {|c| c.status == ClaimStatus::ACTIVE}.each do |claim|
           claim.status = ClaimStatus::EXPIRED
         end
         donation.save
       else
-        @active.push donation
+        active.push donation
       end
     end
-    @active
+    active
   end
 end

--- a/app/controllers/donors_controller.rb
+++ b/app/controllers/donors_controller.rb
@@ -10,7 +10,6 @@ class DonorsController < ApplicationController
 			return
 		end
 		@donor = Donor.find(id)
-
 		render json: expire_donations(@donor.donations), include: 'claims', status: :ok
 	end
 
@@ -21,7 +20,7 @@ class DonorsController < ApplicationController
 			render json: { error: 'Unauthorized' }, status: :forbidden
 			return
 		end
-		active_donations_in_db = Donation.where status: DonationStatus::ACTIVE, donor_id: authorized_id
+		active_donations_in_db = Donation.where status: [DonationStatus::ACTIVE, DonationStatus::CLAIMED], donor_id: authorized_id
 
 		render json: expire_donations(active_donations_in_db), include: 'claims', status: :ok
 	end

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -1,5 +1,5 @@
 class Donation < ApplicationRecord
-
+	attr_accessor :distance
 	belongs_to :donor
 	has_many :claims, autosave: true
 

--- a/app/serializers/donation_serializer.rb
+++ b/app/serializers/donation_serializer.rb
@@ -8,6 +8,7 @@ class DonationSerializer < ActiveModel::Serializer
     :total_amount,
     :pickup_instructions,
     :status,
+    :distance,
     :donor
   #only return donor address info
   def donor

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,4 @@
+Geocoder.configure(
+    timeout: 8,
+    always_raise: :all,
+)

--- a/db/migrate/20200801012821_add_donor_lat_long_idx.rb
+++ b/db/migrate/20200801012821_add_donor_lat_long_idx.rb
@@ -1,0 +1,5 @@
+class AddDonorLatLongIdx < ActiveRecord::Migration[6.0]
+  def change
+    add_index :donors, [:latitude, :longitude]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_24_014011) do
+ActiveRecord::Schema.define(version: 2020_08_01_012821) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -90,6 +90,7 @@ ActiveRecord::Schema.define(version: 2020_07_24_014011) do
     t.string "business_phone_number"
     t.integer "business_doc_id"
     t.string "profile_pic_link"
+    t.index ["latitude", "longitude"], name: "index_donors_on_latitude_and_longitude"
   end
 
   create_table "password_resets", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -177,6 +177,24 @@ donor10 = Donor.create(
 	business_doc_id: '8675309',
 	profile_pic_link: 'http://www.link.com'
 )
+#begin Boston area donors (testing for dhite)
+donor11 = Donor.create(
+		first_name: "Grady",
+		last_name: "Little",
+		organization_name: "Whole Foods Market",
+		email: "donor11@donor11.com",
+		password: "donor10@123",
+		address_street: '27 Austin St',
+		address_city: 'Charlestown',
+		address_state: 'MA',
+		address_zip: '02129',
+		business_license: "123456789",
+		account_status: "approved",
+		pickup_instructions: 'Please go to the front desk.',
+		business_phone_number: '8675309',
+		business_doc_id: '8675309',
+		profile_pic_link: 'http://www.link.com'
+)
 
 puts "Seeding Donations..."
 
@@ -235,6 +253,23 @@ donation9 = Donation.create(
   category: DonationCategory::DAIRY,
   total_amount: "3 gallons",
   status: DonationStatus::ACTIVE
+)
+
+donation10 = Donation.create(
+		food_name: "Milk",
+		donor_id: donor11.id,
+		pickup_instructions: 'front desk',
+		category: DonationCategory::DAIRY,
+		total_amount: "3 gallons",
+		status: DonationStatus::ACTIVE
+)
+donation11 = Donation.create(
+		food_name: "Leftovers from a meeting",
+		donor_id: donor11.id,
+		pickup_instructions: 'in the warehouse',
+		category: DonationCategory::HOT_MEAL,
+		total_amount: "3 dinner plates",
+		status: DonationStatus::ACTIVE
 )
 ## Either delete or migrate these to new table format
 # donation10 = Donation.create(

--- a/test/controllers/donations_controller_test.rb
+++ b/test/controllers/donations_controller_test.rb
@@ -62,8 +62,22 @@ class DonationsControllerTest < ActionDispatch::IntegrationTest
   test "claiming a donation adds a claims table record and changes the donation status to claimed" do
     assert_equal DonationStatus::ACTIVE, Donation.find_by_id(2).status, 'Donation status should start as active'
     post '/donations/2/claim', params: {client_id: 1}, headers: auth_header({client_id: 1})
+    assert_response :success
     assert_equal 1, Claim.find_by_donation_id(2).client_id, 'there should now be a claims record'
     assert_equal DonationStatus::CLAIMED, Donation.find_by_id(2).status, 'Donation status should now be claimed'
+  end
+
+  test "passing client coords includes distance value for donations" do
+    get '/donations/active', params: {client_lat: 47.609175 , client_long: -122.325849}, headers: auth_header({client_id: 1})
+    res_obj = JSON.parse @response.body
+    assert_not_nil res_obj[0]['distance']
+  end
+
+  test "passing client coords filters out results that are more than 20 miles away" do
+    get '/donations/active', params: {client_lat: 46.609175 , client_long: -122.325849}, headers: auth_header({client_id: 1})
+    res_obj = JSON.parse @response.body
+    assert_equal [], res_obj, 'should have returned empty array'
+
   end
 
 end

--- a/test/controllers/donors_controller_test.rb
+++ b/test/controllers/donors_controller_test.rb
@@ -56,19 +56,22 @@ class DonorsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "get donations for donor" do
-    active_donations_in_db = Donation.where status: DonationStatus::ACTIVE
-    assert_equal 2, active_donations_in_db.size, 'should initially have 2 donations with status = active'
+    donations_for_donor = Donation.where donor_id: 1
+    assert_equal 4, donations_for_donor.size, 'should have 4 donations belonging to donor_id = 1'
     get '/donors/1/get_donations', headers: auth_header({donor_id: 1})
     assert_response :success
     donations_api = JSON.parse @response.body
-    assert_equal 2, donations_api.size, 'should return 2 donations'
+    assert_equal 3, donations_api.size, 'should return 3 donations, with one expiring'
   end
 
   test "get active donations for donor" do
     get '/donors/1/get_active_donations', headers: auth_header({donor_id: 1})
     assert_response :success
     active_donations_api = JSON.parse @response.body
-    assert_equal 1, active_donations_api.size, 'should return only 1 active donation'
+    assert_equal 2, active_donations_api.size, 'should return one active and one claimed donation'
+    statuses = active_donations_api.map{|d| d['status']}
+    assert statuses.include?(DonationStatus::ACTIVE)
+    assert statuses.include?(DonationStatus::CLAIMED)
   end
 
 end

--- a/test/fixtures/claims.yml
+++ b/test/fixtures/claims.yml
@@ -13,3 +13,10 @@ two:
   donation_id: 1
   qr_code: MyString
   status: <%= ClaimStatus::ACTIVE %>
+
+three:
+  id: 3
+  client_id: 1
+  donation_id: 4
+  qr_code: Foobar
+  status: <%= ClaimStatus::ACTIVE %>

--- a/test/fixtures/donations.yml
+++ b/test/fixtures/donations.yml
@@ -26,3 +26,12 @@ closed:
   total_amount: '1 bunch'
   pickup_instructions: 'side door'
   status: <%= DonationStatus::CLOSED %>
+anotherActive:
+  id: 4
+  donor_id: 1
+  food_name: 'Cheese'
+  created_at: <%= 2.hours.ago %>
+  category: <%= DonationCategory::DAIRY %>
+  total_amount: '5 pounds'
+  pickup_instructions: 'Around the back'
+  status: <%= DonationStatus::CLAIMED %>


### PR DESCRIPTION
…estrict donations to within a 20 mile radius of the user's location if client coordinates are passed in the request

# Pull Request Template

#### Please check if the PR fulfills these requirements

- [x] The changes don't come from your master branch. ([Source](https://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)) 

---

### [Trello Card](trello.com/LINK-TO-TRELLO-CARD)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
New feature.


#### What is the current behavior? (You can also link to an open issue here)
When retrieving active donations for the client, we don't consider the client's location in terms of what's returned.  


#### What is the new behavior? (if this is a feature change)
Now, if the client coords are passed in the request, we'll only return donations within a 20 mile radius of that location and include a crow fly distance from the client to each donation.


#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No


#### Other information



#### Discussion Questions



#### Images (before/ after screenshots, interaction GIFs, ...)


---



