### PR TITLE
Fetches donations and claim history for donor and client respectively

### DIFF
--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -8,6 +8,17 @@ class DonationsController < ApplicationController
 		render json: Donation.all
 	end
 
+    def donations_history
+        id = params[:donor_id].to_i
+        closed_donations_in_db = Donation.where(:status => [DonationStatus::CLOSED, DonationStatus::EXPIRED], donor_id: id).order("updated_at DESC").limit(50)
+        render json: closed_donations_in_db
+    end
+
+    def claims_history
+        id = params[:client_id].to_i
+        closed_claims_in_db = Claim.where(:status =>  [ClaimStatus::CLOSED], client_id: id).order("updated_at DESC").limit(50)
+        render json: closed_claims_in_db
+    end
 
 	def active
 		@active_donations_in_db = Donation.where status: DonationStatus::ACTIVE

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -9,7 +9,11 @@ class DonationsController < ApplicationController
 	end
 
     def donations_history
-        id = params[:donor_id].to_i
+     id = params[:donor_id].to_i
+				authorized_id = decoded_token[0]['donor_id']
+				if authorized_id != id
+					return render json: { error: 'unauthorized'}, status: :unauthorized
+				end
         closed_donations_in_db = Donation.where(:status => [DonationStatus::CLOSED, DonationStatus::EXPIRED], donor_id: id).order("updated_at DESC").limit(50)
         render json: closed_donations_in_db
     end

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -9,17 +9,21 @@ class DonationsController < ApplicationController
 	end
 
     def donations_history
-     id = params[:donor_id].to_i
-				authorized_id = decoded_token[0]['donor_id']
-				if authorized_id != id
-					return render json: { error: 'unauthorized'}, status: :unauthorized
-				end
+     	id = params[:donor_id].to_i
+	authorized_id = decoded_token[0]['donor_id']
+	if authorized_id != id
+		return render json: { error: 'unauthorized'}, status: :unauthorized
+	end
         closed_donations_in_db = Donation.where(:status => [DonationStatus::CLOSED, DonationStatus::EXPIRED], donor_id: id).order("updated_at DESC").limit(50)
         render json: closed_donations_in_db
     end
 
     def claims_history
         id = params[:client_id].to_i
+	authorized_id = decoded_token[0]['client_id']
+	if authorized_id != id
+		return render json: { error: 'unauthorized'}, status: :unauthorized
+	end
         closed_claims_in_db = Claim.where(:status =>  [ClaimStatus::CLOSED], client_id: id).order("updated_at DESC").limit(50)
         render json: closed_claims_in_db
     end

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -8,25 +8,25 @@ class DonationsController < ApplicationController
 		render json: Donation.all
 	end
 
-    def donations_history
-     	id = params[:donor_id].to_i
-	authorized_id = decoded_token[0]['donor_id']
-	if authorized_id != id
-		return render json: { error: 'unauthorized'}, status: :unauthorized
+	def donations_history
+		id = params[:donor_id].to_i
+		authorized_id = decoded_token[0]['donor_id']
+		if authorized_id != id
+			return render json: { error: 'unauthorized'}, status: :unauthorized
+		end
+		closed_donations_in_db = Donation.where(:status => [DonationStatus::CLOSED, DonationStatus::EXPIRED], donor_id: id).order("updated_at DESC").limit(50)
+		render json: closed_donations_in_db
 	end
-        closed_donations_in_db = Donation.where(:status => [DonationStatus::CLOSED, DonationStatus::EXPIRED], donor_id: id).order("updated_at DESC").limit(50)
-        render json: closed_donations_in_db
-    end
 
-    def claims_history
-        id = params[:client_id].to_i
-	authorized_id = decoded_token[0]['client_id']
-	if authorized_id != id
-		return render json: { error: 'unauthorized'}, status: :unauthorized
+	def claims_history
+		id = params[:client_id].to_i
+		authorized_id = decoded_token[0]['client_id']
+		if authorized_id != id
+			return render json: { error: 'unauthorized'}, status: :unauthorized
+		end
+		closed_claims_in_db = Claim.where(:status =>  [ClaimStatus::CLOSED], client_id: id).order("updated_at DESC").limit(50)
+		render json: closed_claims_in_db
 	end
-        closed_claims_in_db = Claim.where(:status =>  [ClaimStatus::CLOSED], client_id: id).order("updated_at DESC").limit(50)
-        render json: closed_claims_in_db
-    end
 
 	def active
 		@active_donations_in_db = Donation.where status: DonationStatus::ACTIVE

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
   patch 'donations/:id/update', to: 'donations#update'
   post 'donations/:id/claim', to: 'donations#make_claim'
   get 'donations/active', to: 'donations#active'
+  get 'donations/:donor_id/history_donations', to: 'donations#donations_history'
+  get 'donations/:client_id/history_claims', to: 'donations#claims_history'
 
   get 'clients/:id/get_claims', to: 'clients#get_claims'
   post 'client_auth', to: 'client_auth#create'

--- a/test/controllers/donations_controller_test.rb
+++ b/test/controllers/donations_controller_test.rb
@@ -62,15 +62,13 @@ class DonationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "claims history returns list of closed claims" do
-    get '/donations/1/history_claims', headers: auth_header({client_id: 1})
+ get '/donations/1/history_claims', headers: auth_header({client_id: 1})
     assert_response :success
     history = JSON.parse @response.body
-    claim_in_db = Claim.where(:client_id => 1, :status => [ClaimStatus::CLOSED]).order("updated_at desc").limit(3)
+    claim_in_db = Claim.where(:client_id => 1, :status => [ClaimStatus::CLOSED]).order("updated_at desc")
     assert_equal history.count,claim_in_db.count, 'Incorrect number of claims received in the response'
-    i = 0
-    claim_in_db.each do |claim|
-      assert_equal claim.status, history[i]['status'], 'The status of claim: #{history[i]["id"]}, is invalid'
-      i +=1
+    claim_in_db.each_with_index do |claim, i|
+      assert_equal claim.status, history[i]['status'], "The status of claim: #{history[i]['id']}, is invalid"
     end
   end
 

--- a/test/controllers/donations_controller_test.rb
+++ b/test/controllers/donations_controller_test.rb
@@ -49,7 +49,7 @@ class DonationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "donations history returns list of closed and expired donations" do
- get '/donations/1/history_donations', headers: auth_header({donor_id: 1})
+    get '/donations/1/history_donations', headers: auth_header({donor_id: 1})
     assert_response :success
     history = JSON.parse @response.body
     donation_in_db = Donation.where(:donor_id => 1, :status => [DonationStatus::CLOSED, DonationStatus::EXPIRED]).order("updated_at desc")
@@ -60,7 +60,7 @@ class DonationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "claims history returns list of closed claims" do
- get '/donations/1/history_claims', headers: auth_header({client_id: 1})
+    get '/donations/1/history_claims', headers: auth_header({client_id: 1})
     assert_response :success
     history = JSON.parse @response.body
     claim_in_db = Claim.where(:client_id => 1, :status => [ClaimStatus::CLOSED]).order("updated_at desc")

--- a/test/controllers/donations_controller_test.rb
+++ b/test/controllers/donations_controller_test.rb
@@ -49,15 +49,13 @@ class DonationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "donations history returns list of closed and expired donations" do
-    get '/donations/1/history_donations', headers: auth_header({donor_id: 1})
+ get '/donations/1/history_donations', headers: auth_header({donor_id: 1})
     assert_response :success
     history = JSON.parse @response.body
-    donation_in_db = Donation.where(:donor_id => 1, :status => [DonationStatus::CLOSED, DonationStatus::EXPIRED]).order("updated_at desc").limit(3)
+    donation_in_db = Donation.where(:donor_id => 1, :status => [DonationStatus::CLOSED, DonationStatus::EXPIRED]).order("updated_at desc")
     assert_equal history.count,donation_in_db.count, 'Incorrect number of donations received in the response'
-    i = 0
-    donation_in_db.each do |donation|
-      assert_equal donation.status, history[i]['status'], 'The status of donation: #{history[i]["id"]}, is invalid'
-      i +=1
+    donation_in_db.each_with_index do |donation, i|
+      assert_equal donation.status, history[i]['status'], "The status of donation: #{history[i]['id']}, is invalid"
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,7 @@ require 'rails/test_help'
 
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers
-  parallelize(workers: :number_of_processors)
+  # parallelize(workers: :number_of_processors)
 
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all


### PR DESCRIPTION
# Pull Request Template

#### Please check if the PR fulfills these requirements

- [ ] The changes don't come from your master branch. ([Source](https://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)) 

---

### [Trello Card](https://trello.com/c/uBegXM1j/263-add-rails-api-end-points-to-fetch-donation-and-claim-history-for-donor-and-client-respectively)


#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Added rails API endpoints to fetch donation and claim history for donor and client respectively.


#### What is the current behavior? (You can also link to an open issue here)



#### What is the new behavior? (if this is a feature change)
Displays the list of donations that are closed and expired on the donor history page. Also, displays the list of claims that are closed on the client history page and limiting those results to the top 50


#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)



#### Other information



#### Discussion Questions



#### Images (before/ after screenshots, interaction GIFs, ...)


---


#### TODO
 - this
 - that
 - the other

