### PR TITLE
Fetches claims history for client

### DIFF
--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -84,12 +84,10 @@ class ClientsController < ApplicationController
     active_claims_for_client = Claim.where client_id: params[:id].to_i, status: ClaimStatus::ACTIVE
     donations = active_claims_for_client.map(&:donation)
     still_active = expire_donations(donations)
-
     if params[:client_lat] && params[:client_long]
       client_coords = [params[:client_lat].to_f, params[:client_long].to_f]
       still_active.each {|d| d.distance = d.donor.distance_to(client_coords)}
     end
-
     render json: still_active, status: :ok
   end
 

--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -81,7 +81,12 @@ class ClientsController < ApplicationController
 
 
   def get_claims
-    active_claims_for_client = Claim.where client_id: params[:id].to_i, status: ClaimStatus::ACTIVE
+    id = params[:id].to_i
+    authorized_id = decoded_token[0]['client_id']
+    if authorized_id != id
+      return render json: { error: 'unauthorized'}, status: :unauthorized
+    end
+    active_claims_for_client = Claim.where client_id: id, status: ClaimStatus::ACTIVE
     donations = active_claims_for_client.map(&:donation)
     still_active = expire_donations(donations)
     if params[:client_lat] && params[:client_long]

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -18,19 +18,6 @@ class DonationsController < ApplicationController
 		render json: closed_donations_in_db
 	end
 
-<<<<<<< Updated upstream
-	def claims_history
-		id = params[:client_id].to_i
-		authorized_id = decoded_token[0]['client_id']
-		if authorized_id != id
-			return render json: { error: 'unauthorized'}, status: :unauthorized
-		end
-		closed_claims_in_db = Claim.where(:status =>  [ClaimStatus::CLOSED], client_id: id).order("updated_at DESC").limit(50)
-		render json: closed_claims_in_db
-	end
-
-=======
->>>>>>> Stashed changes
 	def active
 		@active_donations_in_db = Donation.where status: DonationStatus::ACTIVE
 		non_expired_donations = expire_donations(@active_donations_in_db)

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -18,6 +18,7 @@ class DonationsController < ApplicationController
 		render json: closed_donations_in_db
 	end
 
+<<<<<<< Updated upstream
 	def claims_history
 		id = params[:client_id].to_i
 		authorized_id = decoded_token[0]['client_id']
@@ -28,6 +29,8 @@ class DonationsController < ApplicationController
 		render json: closed_claims_in_db
 	end
 
+=======
+>>>>>>> Stashed changes
 	def active
 		@active_donations_in_db = Donation.where status: DonationStatus::ACTIVE
 		non_expired_donations = expire_donations(@active_donations_in_db)

--- a/app/serializers/donation_serializer.rb
+++ b/app/serializers/donation_serializer.rb
@@ -24,7 +24,7 @@ class DonationSerializer < ActiveModel::Serializer
 
   def claim
     self.object.claims[0].nil? ? nil : {client_name: self.object.claims[0].client.first_name,
-                                        qr_code: self.object.claims[0].qr_code}
+                                        qr_code: self.object.claims[0].qr_code, status: self.object.claims[0].status}
   end
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,6 @@ Rails.application.routes.draw do
   post 'donations/:id/claim', to: 'donations#make_claim'
   get 'donations/active', to: 'donations#active'
   get 'donations/:donor_id/history_donations', to: 'donations#donations_history'
-  get 'donations/:client_id/history_claims', to: 'donations#claims_history'
 
   get 'clients/:id/get_claims', to: 'clients#get_claims'
   get 'clients/:donorid/travel_times', to: 'clients#get_travel_times'
@@ -23,6 +22,7 @@ Rails.application.routes.draw do
   patch 'clients/:id/updateStatus', to: 'clients#account_status_update'
   post 'clients/:id/get_donations', to: 'clients#get_donations'
   patch 'clients/:id/update', to: 'clients#update'
+  get 'clients/:id/claims_history', to: 'clients#claims_history'
 
   post 'admin_auth', to: 'admin_auth#create'
 

--- a/test/controllers/clients_controller_test.rb
+++ b/test/controllers/clients_controller_test.rb
@@ -56,7 +56,6 @@ class ClientsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 1, claims.size, 'should only be one active/pending claim'
   end
 
-<<<<<<< Updated upstream
   test "get travel times to donation for client" do
     coords = Geocoder.coordinates("800 8th Ave Seattle, WA")
     puts coords
@@ -68,17 +67,16 @@ class ClientsControllerTest < ActionDispatch::IntegrationTest
       assert_response :not_found
     end
   end
-=======
-test "claims history returns list of closed claims" do
-  get '/clients/2/claims_history', headers: auth_header({client_id: 1})
-  assert_response :success
-  history = JSON.parse @response.body
-  closed_claims = Claim.where(:client_id => 2, status: ClaimStatus::CLOSED)
-  assert_equal history.count, closed_claims.count, 'Incorrect number of claims received in the response'
-  closed_claims.each_with_index do |claim, i|
-      assert_equal claim.status, history[i]['status'], "The status of claim: #{history[i]['id']}, is invalid"
+
+  test "claims history returns list of closed claims" do
+    get '/clients/2/claims_history', headers: auth_header({client_id: 1})
+    assert_response :success
+    history = JSON.parse @response.body
+    closed_claims = Claim.where(:client_id => 2, status: ClaimStatus::CLOSED)
+    assert_equal history.count, closed_claims.count, 'Incorrect number of claims received in the response'
+    closed_claims.each_with_index do |claim, i|
+        assert_equal claim.status, history[i]['status'], "The status of claim: #{history[i]['id']}, is invalid"
   end
 end
->>>>>>> Stashed changes
 
 end

--- a/test/controllers/clients_controller_test.rb
+++ b/test/controllers/clients_controller_test.rb
@@ -56,6 +56,7 @@ class ClientsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 1, claims.size, 'should only be one active/pending claim'
   end
 
+<<<<<<< Updated upstream
   test "get travel times to donation for client" do
     coords = Geocoder.coordinates("800 8th Ave Seattle, WA")
     puts coords
@@ -67,5 +68,17 @@ class ClientsControllerTest < ActionDispatch::IntegrationTest
       assert_response :not_found
     end
   end
+=======
+test "claims history returns list of closed claims" do
+  get '/clients/2/claims_history', headers: auth_header({client_id: 1})
+  assert_response :success
+  history = JSON.parse @response.body
+  closed_claims = Claim.where(:client_id => 2, status: ClaimStatus::CLOSED)
+  assert_equal history.count, closed_claims.count, 'Incorrect number of claims received in the response'
+  closed_claims.each_with_index do |claim, i|
+      assert_equal claim.status, history[i]['status'], "The status of claim: #{history[i]['id']}, is invalid"
+  end
+end
+>>>>>>> Stashed changes
 
 end

--- a/test/controllers/clients_controller_test.rb
+++ b/test/controllers/clients_controller_test.rb
@@ -58,7 +58,6 @@ class ClientsControllerTest < ActionDispatch::IntegrationTest
 
   test "get travel times to donation for client" do
     coords = Geocoder.coordinates("800 8th Ave Seattle, WA")
-    puts coords
     get "/clients/1/travel_times?client_lat=#{coords[0]}&client_long=#{coords[1]}", headers: auth_header({client_id: 1})
     #eventually we'll want to figure out how to pass this secret to tests
     if ENV["HERE_API_KEY"]
@@ -69,13 +68,13 @@ class ClientsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "claims history returns list of closed claims" do
-    get '/clients/2/claims_history', headers: auth_header({client_id: 1})
+    get '/clients/1/claims_history', headers: auth_header({client_id: 1})
     assert_response :success
     history = JSON.parse @response.body
-    closed_claims = Claim.where(:client_id => 2, status: ClaimStatus::CLOSED)
+    closed_claims = Claim.where(:client_id => 1, status: ClaimStatus::CLOSED)
     assert_equal history.count, closed_claims.count, 'Incorrect number of claims received in the response'
     closed_claims.each_with_index do |claim, i|
-        assert_equal claim.status, history[i]['status'], "The status of claim: #{history[i]['id']}, is invalid"
+      assert_equal claim.status, history[i]['claim']['status'], "The status of claim: #{history[i]['id']}, is invalid"
   end
 end
 

--- a/test/controllers/donations_controller_test.rb
+++ b/test/controllers/donations_controller_test.rb
@@ -59,6 +59,7 @@ class DonationsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+<<<<<<< Updated upstream
   test "claims history returns list of closed claims" do
     get '/donations/1/history_claims', headers: auth_header({client_id: 1})
     assert_response :success
@@ -70,6 +71,8 @@ class DonationsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+=======
+>>>>>>> Stashed changes
   test "only updates to donations owned by logged in donor" do
     patch '/donations/2/update', params: {donation: {id:2, status:DonationStatus::DELETED}}, headers: auth_header({donor_id: 2})
     assert_response :unauthorized

--- a/test/controllers/donations_controller_test.rb
+++ b/test/controllers/donations_controller_test.rb
@@ -59,20 +59,6 @@ class DonationsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-<<<<<<< Updated upstream
-  test "claims history returns list of closed claims" do
-    get '/donations/1/history_claims', headers: auth_header({client_id: 1})
-    assert_response :success
-    history = JSON.parse @response.body
-    claim_in_db = Claim.where(:client_id => 1, :status => [ClaimStatus::CLOSED]).order("updated_at desc")
-    assert_equal history.count,claim_in_db.count, 'Incorrect number of claims received in the response'
-    claim_in_db.each_with_index do |claim, i|
-      assert_equal claim.status, history[i]['status'], "The status of claim: #{history[i]['id']}, is invalid"
-    end
-  end
-
-=======
->>>>>>> Stashed changes
   test "only updates to donations owned by logged in donor" do
     patch '/donations/2/update', params: {donation: {id:2, status:DonationStatus::DELETED}}, headers: auth_header({donor_id: 2})
     assert_response :unauthorized


### PR DESCRIPTION
# Pull Request Template

#### Please check if the PR fulfills these requirements

- [ ] The changes don't come from your master branch. ([Source](https://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)) 

---

### [Trello Card](trello.com/LINK-TO-TRELLO-CARD)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Added rails API endpoints to fetch claim history for the client.


#### What is the current behavior? (You can also link to an open issue here)



#### What is the new behavior? (if this is a feature change)
Displays the list of donations that are closed and expired on the donor history page. Also, displays the list of claims that are closed on the client history page and limiting those results to the top 50


#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)



#### Other information



#### Discussion Questions



#### Images (before/ after screenshots, interaction GIFs, ...)


---


#### TODO
 - this
 - that
 - the other

