### PR TITLE
Create site association file for saving passwords in Apple Keychain

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,15 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "com.thebegoodproject.org.bananaapp",
+        "paths": ["*"]
+      },
+      {
+        "appID": "com.thebegoodproject.org.bananaapp-client",
+        "paths": ["*"]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
# Pull Request Template

#### Please check if the PR fulfills these requirements

- [x] The changes don't come from your master branch. ([Source](https://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)) 

---

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

This PR creates a site association file necessary to use Apple Keychain for storing passwords as discussed here:
* [Password Autofill](https://developer.apple.com/documentation/security/password_autofill) - Password AutoFill simplifies login and account creation tasks for iOS apps and webpages.
* [Support Universal Links](https://developer.apple.com/library/archive/documentation/General/Conceptual/AppSearch/UniversalLinks.html) - When you support universal links, iOS users can tap a link to your website and get seamlessly redirected to your installed app without going through Safari.
* [iOS12 - Password AutoFill, Automatic Strong Password, and Security Code AutoFill](https://developerinsider.co/ios12-password-autofill-automatic-strong-password-and-security-code-autofill/) - I grabbed a lot of information from this guide

#### What is the current behavior? (You can also link to an open issue here)

This file is new. At present, iOS users are unable to save their password in the Keychain or use a "Suggested Password"


#### What is the new behavior? (if this is a feature change)

iOS users should be able to save their app password in the Keychain along with getting an option to use a "Suggested Password" when registering for the first time. It will also allow them to sign in using the saved password in their Keychain

#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No


#### Other information

The structure of the file (and name) come from [Listing 6-1](https://developer.apple.com/library/archive/documentation/General/Conceptual/AppSearch/UniversalLinks.html) of the "Support Universal Links"  guide.

#### Discussion Questions

So far as I can tell, the ".well-known" directory belongs in the public folder of the site when adding it to rails


#### Images (before/ after screenshots, interaction GIFs, ...)


---


#### TODO

